### PR TITLE
Fix for empty IP address in notification email

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Define a new action in fail2ban at: `/etc/fail2ban/action.d/mailgun.conf`
     actionstart =
     actionstop =
     actioncheck =
-    actionban = /usr/local/bin/fail2ban-mailgun/mail.sh ban
-    actionun = /usr/local/bin/fail2ban-mailgun/mail.sh unban
+    actionban = /usr/local/bin/fail2ban-mailgun/mail.sh ban <ip>
+    actionunban = /usr/local/bin/fail2ban-mailgun/mail.sh unban <ip>
 
 Modify or add an action entry in the jail you wish to configure. We're assuming
 that you've copied jail.conf to jail.local and will be adding this rule to the

--- a/mail.sh
+++ b/mail.sh
@@ -10,7 +10,7 @@ function send_sms {
   https://api.mailgun.net/v3/$mailgun_domain/messages -F from='$from' \
   -F to='$to' \
   -F subject='$server - fail2ban $message an IP' \
-  -F text='fail2ban $1 IP: <ip>'"
+  -F text='fail2ban $1 IP: $2'"
   echo $mailgun_call
   eval $mailgun_call
   exit
@@ -19,8 +19,8 @@ function send_sms {
 if [ "$1" = 'ban' ]
 then
   message="banned"
-  send_sms $message
+  send_sms $message, $2
 else
   message="unbanned"
-  send_sms $message
+  send_sms $message, $2
 fi


### PR DESCRIPTION
This PR fixes #2 by
- Correcting typo of `actionun` to `actionunban`. See commands [doc](http://www.fail2ban.org/wiki/index.php/Commands) for more info
- Updates action to pass IP address as second parameter to mail script
- Uses second parameter when notifying on ban 

This can easily be improved and is a rather hasty PR.
